### PR TITLE
Treat rrules with no recognized frequency as errors.

### DIFF
--- a/src/pg_rrule.c
+++ b/src/pg_rrule.c
@@ -25,6 +25,13 @@ Datum pg_rrule_in(PG_FUNCTION_ARGS) {
                  errhint("You need to omit \"RRULE:\" part of expression (if present)")));
     }
 
+    if (recurrence.freq == ICAL_NO_RECURRENCE) {
+        // libical 1.0 won't round trip this, so we treat it as an error.
+        ereport(ERROR,
+                (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                 errmsg("Invalid RRULE frequency. RRULE \"%s\".", rrule_str)));
+    }
+
     struct icalrecurrencetype* recurrence_ref = palloc(sizeof(struct icalrecurrencetype));
 
     (*recurrence_ref) = recurrence;


### PR DESCRIPTION
In the most current released version of libical, these calls will return without error.  Note in the second example the separator is incorrect.

    icalrecurrencetype_from_string("FREQ=BANANA")
    icalrecurrencetype_from_string("FREQ=WEEKLY,BYDAY=MO")

However `icalrecurrencetype_as_string()` will not render this result back.  Instead it returns NULL, which causes the rrule output function to segfault.

Since rrules are static in this extension, it makes sense to catch the error in the input function.

It looks like a future release of libical will treat this as an error.
https://github.com/libical/libical/commit/5b99f67f6e7849dc679d53c591bfc87bef880ea9#diff-8161e632c3871bb32c8bc438d66b8c7fR536
